### PR TITLE
base64 end string `==` split fix,  Split replaced to Cut

### DIFF
--- a/kenv.go
+++ b/kenv.go
@@ -35,13 +35,18 @@ func Load(envFiles ...string) {
 			r := bufio.NewScanner(f)
 
 			for r.Scan() {
-				sp := strings.Split(r.Text(), "=")
-				if len(sp) != 2 || r.Text()[0] == '#' {
+				if r.Text()[0] == '#' {
 					continue
 				}
-				sp[0] = strings.TrimSpace(sp[0])
-				sp[1] = strings.TrimSpace(sp[1])
-				err := os.Setenv(sp[0], sp[1])
+				
+				key, val, found := strings.Cut(r.Text(), "=")
+				if !found {
+					continue
+				}
+
+				key = strings.TrimSpace(key)
+				val = strings.TrimSpace(val)
+				err := os.Setenv(key, val)
 				if err != nil {
 					continue
 				}

--- a/tests/.env
+++ b/tests/.env
@@ -1,1 +1,5 @@
+#TEMP=Comment
 HOST=127.0.0.1
+SECRET=MiU3czRkS3U8Zg==
+ID = 100
+CODE==TMP+=

--- a/tests/env_test.go
+++ b/tests/env_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -8,7 +9,10 @@ import (
 )
 
 type Config struct {
-	Host string `kenv:"HOST|localhost"`
+	Host   string `kenv:"HOST|localhost"`
+	Secret string `kenv:"SECRET|"`
+	Id     string `kenv:"ID|"`
+	Code   string `kenv:"CODE|"`
 }
 
 func Test_load_env_file(t *testing.T) {
@@ -18,6 +22,36 @@ func Test_load_env_file(t *testing.T) {
 	kenv.Fill(&cfg)
 
 	if cfg.Host != "127.0.0.1" {
+		t.Logf("config %+v \n", cfg)
+		t.Fail()
+		return
+	}
+
+	t.Logf("config %+v \n", cfg)
+}
+
+func Test_load_env_trim_space(t *testing.T) {
+	cfg := Config{}
+
+	kenv.Load(".env")
+	kenv.Fill(&cfg)
+
+	if cfg.Id != "100" {
+		t.Logf("config %+v \n", cfg)
+		t.Fail()
+		return
+	}
+
+	t.Logf("config %+v \n", cfg)
+}
+
+func Test_load_env_base64_val(t *testing.T) {
+	cfg := Config{}
+
+	kenv.Load(".env")
+	kenv.Fill(&cfg)
+
+	if cfg.Secret != "MiU3czRkS3U8Zg==" {
 		t.Logf("config %+v \n", cfg)
 		t.Fail()
 		return
@@ -48,13 +82,15 @@ func Test_env_file_not_found(t *testing.T) {
 func Test_load_default_tags_no_file(t *testing.T) {
 	cfg := Config{}
 
+	t.Setenv("HOST", "")
+
 	kenv.Fill(&cfg)
+
+	fmt.Printf("config %+v \n", cfg)
 
 	if cfg.Host != "localhost" {
 		t.Logf("config %+v \n", cfg)
 		t.Fail()
 		return
 	}
-
-	t.Logf("config %+v \n", cfg)
 }


### PR DESCRIPTION
Kamal Hi! How are you?

I am trying to fix one call `strings.Split`. 
When I try parce base64 from the `.env` file. I see the character "==" in the end string. 
After reading a file. I get an empty value in the env variable. 

So I thin replace `strings.Split` with `Cut` because we do not need slice string allocation. The `Cut` is returning two keys.
I added some tests.